### PR TITLE
This stops `docker-compose up --build` from rebuilding **every** time.

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -57,6 +57,7 @@ services:
             context: ./
             dockerfile: Dockerfile.dev.drupal
             cache_from:
+              - dev_drupal:latest
               - docker.pkg.github.com/ackama/dpc-user-management-module/drupal-dev:latest
 
         ports:


### PR DESCRIPTION
By explicitly listing the local image name in `cache_from` we ensure that
it is considered a source of layers when deciding which layers need to be
rebuilt.